### PR TITLE
Add support for Debian 8.0 (jessie)

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,22 +32,16 @@ class sssd::params {
           case $::lsbdistrelease {
             '14.04': {
               $unsupported = false
-
-              $manage_package = true
-              $package_name = ['sssd','sssd-ldap','sssd-tools','sudo']
-              $package_ensure = 'present'
-
-              $manage_config = true
-              $config_path = '/etc/sssd/sssd.conf'
-              $config_owner = 'root'
-              $config_group = 'root'
-              $config_mode  = '0600'
-
-              $manage_service = true
-              $service_name = 'sssd'
-              $service_ensure = 'running'
-              $service_enable = true
-              $sss_cache_path = [ '/usr/sbin/' ]
+            }
+            default: {
+              $unsupported = true
+            }
+          }
+        }
+        'Debian': {
+          case $::lsbdistrelease {
+            /8\.[0-9]+/: {
+              $unsupported = false
             }
             default: {
               $unsupported = true
@@ -58,6 +52,22 @@ class sssd::params {
           $unsupported = true
         }
       }
+
+      $manage_package = true
+      $package_name = ['sssd','sssd-ldap','sssd-tools','sudo']
+      $package_ensure = 'present'
+
+      $manage_config = true
+      $config_path = '/etc/sssd/sssd.conf'
+      $config_owner = 'root'
+      $config_group = 'root'
+      $config_mode  = '0600'
+
+      $manage_service = true
+      $service_name = 'sssd'
+      $service_ensure = 'running'
+      $service_enable = true
+      $sss_cache_path = [ '/usr/sbin/' ]
     }
     default: {
       $unsupported = true


### PR DESCRIPTION
Try to add Debian jessie to the list of supported platforms without introducing any redundancy.

Since all debianesque distros use the same paths and package names, I just moved them to an outer block. The unsupported variable should still make sure they're not used inadvertently. As differences are discovered (e.g. sssd-ldap doesn't exist in Debian squeeze), they can be moved back to more specific scopes.