### PR TITLE
Fix for future parser

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,7 +4,7 @@
 #  The main entry point for the module is the init class
 #
 
-class sssd::config {
+class sssd::config inherits sssd {
   if $sssd::manage_config {
     if $sssd::config_source == '' {
       file { $sssd::config_path:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -84,8 +84,9 @@ class sssd (
   validate_bool($unsupported)
   validate_bool($override_unsupported)
 
+  anchor { 'sssd::begin': } ->
   class { 'sssd::install': } ->
   class { 'sssd::config': } ~>
   class { 'sssd::service': } ->
-  Class['sssd']
+  anchor { 'sssd::end': }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,23 +29,17 @@ class sssd::params {
     'Debian': {
       case $::operatingsystem {
         'Ubuntu': {
-          case $::lsbdistrelease {
-            '14.04': {
-              $unsupported = false
-            }
-            default: {
-              $unsupported = true
-            }
+          if versioncmp($::operatingsystemrelease, '14.04') == 0 {
+            $unsupported = false
+          } else {
+            $unsupported = true
           }
         }
         'Debian': {
-          case $::lsbdistrelease {
-            /8\.[0-9]+/: {
-              $unsupported = false
-            }
-            default: {
-              $unsupported = true
-            }
+          if versioncmp($::operatingsystemrelease, '8.0') >= 0 {
+            $unsupported = false
+          } else {
+            $unsupported = true
           }
         }
         default: {


### PR DESCRIPTION
Fix #4
Fix for future parser, when using stock config template.
Also use anchor pattern to avoid inner classes not behaving with dependencies.