### PR TITLE
rename invalid service "passwd" to "pam"

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -72,7 +72,7 @@ class sssd::params {
   $config_source = ''
   $config_content = ''
   $config_template = 'sssd/sssd.conf.erb'
-  $services = ['nss','passwd']
+  $services = ['nss','pam']
   $domains = {
     'local' => {
       'id_provider'      => 'local',


### PR DESCRIPTION
According to the [sssd.conf(5) man page](http://linux.die.net/man/5/sssd.conf) the service _passwd_ is not valid. I think this is a typo and should be _pam_ instead. In my case the sssd service would not work if _passwd_ was added as a service.