### PR TITLE
quote the first param to versioncmp to avoid type versus String issues

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,14 +29,14 @@ class sssd::params {
     'Debian': {
       case $::operatingsystem {
         'Ubuntu': {
-          if versioncmp($::operatingsystemrelease, '14.04') == 0 {
+          if versioncmp("$::operatingsystemrelease", '14.04') == 0 {
             $unsupported = false
           } else {
             $unsupported = true
           }
         }
         'Debian': {
-          if versioncmp($::operatingsystemrelease, '8.0') >= 0 {
+          if versioncmp("$::operatingsystemrelease", '8.0') >= 0 {
             $unsupported = false
           } else {
             $unsupported = true


### PR DESCRIPTION
In our Puppet 3.7.3 environment the lack of quotes fo the first parameter/Facter value of versioncmp() causes Puppet to get confused when comparing values like '15.10' or '14.04' to the 2nd param. 

```
    Failure/Error: should compile.with_all_deps
       error during compilation: undefined method `scan' for 14:Fixnum at /home/nrvale0/workspace/puppet-base/modules/vendor/sssd/manifests/params.pp:32
```

I've not dug all the way down to the bottom of this one but my theory is that it is an interaction between the installed Facter version and Puppet 3.7.x with sort-of/kind-of typing.

This patch is an attempt to eliminate the compile-time confusion.