### PR TITLE
Support for newer ubuntu versions

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,6 +31,8 @@ class sssd::params {
         'Ubuntu': {
           if versioncmp($::operatingsystemrelease, '14.04') == 0 {
             $unsupported = false
+          } elsif versioncmp($::operatingsystemrelease, '15.10') == 0 {
+            $unsupported = false
           } else {
             $unsupported = true
           }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,9 +29,8 @@ class sssd::params {
     'Debian': {
       case $::operatingsystem {
         'Ubuntu': {
-          if versioncmp($::operatingsystemrelease, '14.04') == 0 {
-            $unsupported = false
-          } elsif versioncmp($::operatingsystemrelease, '15.10') == 0 {
+          # Check that we're running 14.04 or newer
+          if versioncmp($::operatingsystemrelease, '14.04') >= 0 {
             $unsupported = false
           } else {
             $unsupported = true

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -15,6 +15,7 @@ class sssd::service {
         command     => 'sss_cache -E',
         path        => $sssd::sss_cache_path,
         refreshonly => true,
+        returns     => [0, 2],
         require     => Service[$sssd::service_name]
       }
     }


### PR DESCRIPTION
Just changed the version number validation for Ubuntu to allow anything on 14.04 or newer. I've tested on 15.10 and 16.04 beta without issues.
